### PR TITLE
Release v2.16.28+-jp-2-uroesch

### DIFF
--- a/App/AppInfo/appinfo.ini
+++ b/App/AppInfo/appinfo.ini
@@ -18,8 +18,8 @@ Freeware      = true
 CommercialUse = true
 
 [Version]
-PackageVersion = 2.16.28.1
-DisplayVersion = 2.16.28+-jp-1-uroesch
+PackageVersion = 2.16.28.2
+DisplayVersion = 2.16.28+-jp-2-uroesch
 
 [Control]
 Icons = 1

--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,19 +1,19 @@
 [Version]
-Upstream     = 2.16.28+-jp-1
-Package      = 2.16.28.1
-Display      = 2.16.28+-jp-1-uroesch
+Upstream     = 2.16.28+-jp-2
+Package      = 2.16.28.2
+Display      = 2.16.28+-jp-2-uroesch
 
 [Archive]
 GithubPath1  = sdottaka/winmerge-v2-jp
 GithubAsset1 = winmerge-.*-x64-exe.zip
-URL1         = https://github.com/sdottaka/winmerge-v2-jp/releases/download/2.16.28%2Bjp-1/winmerge-2.16.28-jp-1-x64-exe.zip
-Checksum1    = SHA256::8EF8C0656ADC5A5D60F2ED50C480CC4C894547E234AEDF35E94904E5D33C7E41
+URL1         = https://github.com/sdottaka/winmerge-v2-jp/releases/download/2.16.28%2Bjp-2/winmerge-2.16.28-jp-2-x64-exe.zip
+Checksum1    = SHA256::BF886B49147FCF86E14115112BDFF25291FDC768F7AD74D798EE3F5C208225E4
 TargetName1  = WinMerge64
 ExtractName1 = WinMerge
 GithubPath2  = sdottaka/winmerge-v2-jp
 GithubAsset2 = winmerge-.*-jp-[0-9]*-exe.zip
-URL2         = https://github.com/sdottaka/winmerge-v2-jp/releases/download/2.16.28%2Bjp-1/winmerge-2.16.28-jp-1-exe.zip
-Checksum2    = SHA256::ACF934FF673FFA03732CF6ED63AA92B861913A23E5CA79DA51CD5A250427CA48
+URL2         = https://github.com/sdottaka/winmerge-v2-jp/releases/download/2.16.28%2Bjp-2/winmerge-2.16.28-jp-2-exe.zip
+Checksum2    = SHA256::AEF5541DB79B885BA968F7F75662DB8FF2BCAA0EE0AD10C4207C005A11378A7A
 TargetName2  = WinMerge32
 ExtractName2 = WinMerge
 


### PR DESCRIPTION
Summary:
  * Upstream release v2.16.28+-jp-2